### PR TITLE
Add keyof example to unwrap method

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,12 @@ class MyViewModel {
   unwrap(key: string) {
     return unwrap(this, key);
   }
+  
+  // from TypeScript 2.1 you can use keyof
+  // to restrict to keys of the given type
+  unwrap(key: keyof MyViewModel){
+    return unwrap(this, key);
+  }
 }
 ```
 ```html


### PR DESCRIPTION
Typescript 2.1 allows a keyof type to restrict the values of the string passed in to be only a key of the given type. Very useful for the unwrap method.