### PR TITLE
Using types from knockout package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,12 +44,6 @@
       "integrity": "sha512-wNMwXSUcwyYajtbayfPp55tSayuDVU6PfY5gzvRSj80UvxdXEJOVPnUVajaOp7NgXLm+1e2ZDLULmpsU9vDvQw==",
       "dev": true
     },
-    "@types/knockout": {
-      "version": "3.4.59",
-      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.59.tgz",
-      "integrity": "sha512-uLVb9AWPnQajGE8QETNVS2qPpxTVzsWOWP9dLwBrqfIkatR3mCOoU3QP8idI4YDwRRxdTlYgfSeMFbUOjENvyw==",
-      "dev": true
-    },
     "@types/node": {
       "version": "10.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1741,8 +1741,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1763,14 +1762,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1785,20 +1782,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1915,8 +1909,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1928,7 +1921,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1943,7 +1935,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1951,14 +1942,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1977,7 +1966,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2058,8 +2046,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2071,7 +2058,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2157,8 +2143,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2194,7 +2179,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2214,7 +2198,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2258,14 +2241,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2395,9 +2376,9 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "homepage": "https://github.com/gnaeus/knockout-decorators#readme",
   "devDependencies": {
     "@types/jest": "^23.3.9",
-    "@types/knockout": "^3.4.53",
     "coveralls": "^3.0.2",
     "deepmerge": "^2.1.0",
     "jest": "^23.6.0",
@@ -57,7 +56,7 @@
     "typescript": "^2.8.1"
   },
   "peerDependencies": {
-    "knockout": "^3.4.2"
+    "knockout": "^3.5.0"
   },
   "jest": {
     "collectCoverage": true,

--- a/src/experimental/observable-array-proxy.ts
+++ b/src/experimental/observable-array-proxy.ts
@@ -13,13 +13,13 @@ export class ObservableArrayProxy<T> extends ArrayStub {
   static _maxLength = 0;
 
   /** @private */
-  _observableArray: KnockoutObservableArray<T>;
+  _observableArray: ko.ObservableArray<T>;
 
   /** @private */
   _preapreArrayItem: (item: T) => T;
 
   constructor(
-    observableArray: KnockoutObservableArray<T>,
+    observableArray: ko.ObservableArray<T>,
     preapreArrayItem?: (item: T) => T,
   ) {
     super();

--- a/src/knockout-decorators.ts
+++ b/src/knockout-decorators.ts
@@ -99,9 +99,9 @@ export interface ObservableArray<T> extends Array<T> {
   destroyAll(): void;
   destroyAll(items: T[]): void;
 
-  subscribe(callback: (val: T[]) => void): KnockoutSubscription;
-  subscribe(callback: (val: T[]) => void, callbackTarget: any): KnockoutSubscription;
-  subscribe(callback: (val: any[]) => void, callbackTarget: any, event: string): KnockoutSubscription;
+  subscribe(callback: (val: T[]) => void): ko.Subscription;
+  subscribe(callback: (val: T[]) => void, callbackTarget: any): ko.Subscription;
+  subscribe(callback: (val: any[]) => void, callbackTarget: any, event: string): ko.Subscription;
 
   /**
    * Run mutator function that can write to array at some index (`array[index] = value;`)
@@ -319,7 +319,7 @@ export function event(prototype: Object, key: string | symbol) {
 }
 
 export type EventType = Function & {
-  subscribe(callback: Function): KnockoutSubscription;
+  subscribe(callback: Function): ko.Subscription;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -331,7 +331,7 @@ export function subscribe<T>(
   dependencyOrEvent: () => T,
   callback: (value: T) => void,
   options?: { once?: boolean, event?: "change" | "beforeChange" },
-): KnockoutSubscription;
+): ko.Subscription;
 /**
  * Subscribe callback to `@observableArray` dependency "arrayChange" event
  */
@@ -343,7 +343,7 @@ export function subscribe<T>(
     index: number;
   }[]) => void,
   options: { once?: boolean, event: "arrayChange" },
-): KnockoutSubscription;
+): ko.Subscription;
 /**
  * Subscribe callback to some `@event` property
  */
@@ -351,7 +351,7 @@ export function subscribe<T>(
   event: (arg: T) => void,
   callback: (arg: T) => void,
   options?: { once?: boolean },
-): KnockoutSubscription;
+): ko.Subscription;
 /**
  * Subscribe callback to some `@event` property
  */
@@ -359,7 +359,7 @@ export function subscribe<T1, T2>(
   event: (arg1: T1, arg2: T2) => void,
   callback: (arg1: T1, arg2: T2) => void,
   options?: { once?: boolean },
-): KnockoutSubscription;
+): ko.Subscription;
 /**
  * Subscribe callback to some `@event` property
  */
@@ -367,7 +367,7 @@ export function subscribe<T1, T2, T3>(
   event: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => void,
   callback: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => void,
   options?: { once?: boolean },
-): KnockoutSubscription;
+): ko.Subscription;
 /**
  * Subscribe callback to `@observable` or `@computed` dependency changes or to some `@event`
  */
@@ -396,7 +396,7 @@ export function subscribe(
     const eventFunc = options && options.event || "change";
 
     let handler: (value: any) => void;
-    let subscription: KnockoutSubscription;
+    let subscription: ko.Subscription;
 
     if (once) {
       handler = function () {
@@ -422,7 +422,7 @@ export function subscribe(
 
       const originalDispose = subscription.dispose;
       // dispose hidden computed with subscription
-      subscription.dispose = function (this: KnockoutSubscription) {
+      subscription.dispose = function (this: ko.Subscription) {
         originalDispose.call(this);
         koComputed.dispose();
       };
@@ -440,7 +440,7 @@ export function unwrap(instance: Object, key: string | symbol): any;
 /**
  * Get internal ko.observable() for object property decodated by @observable
  */
-export function unwrap<T>(instance: Object, key: string | symbol): KnockoutObservable<T>;
+export function unwrap<T>(instance: Object, key: string | symbol): ko.Observable<T>;
 /**
  * Get internal ko.observable() for object property decodated by @observable
  */
@@ -467,7 +467,7 @@ export interface Disposable {
     dependencyOrEvent: () => T,
     callback: (value: T) => void,
     options?: { once?: boolean, event?: "change" | "beforeChange" },
-  ): KnockoutSubscription;
+  ): ko.Subscription;
   /** Subscribe callback to `@observableArray` dependency "arrayChange" event */
   subscribe<T>(
     dependency: () => T[],
@@ -477,30 +477,30 @@ export interface Disposable {
       index: number;
     }[]) => void,
     options: { once?: boolean, event: "arrayChange" },
-  ): KnockoutSubscription;
+  ): ko.Subscription;
   /** Subscribe callback to some `@event` property */
   subscribe<T>(
     event: (arg: T) => void,
     callback: (arg: T) => void,
     options?: { once?: boolean },
-  ): KnockoutSubscription;
+  ): ko.Subscription;
   /** Subscribe callback to some `@event` property */
   subscribe<T1, T2>(
     event: (arg1: T1, arg2: T2) => void,
     callback: (arg1: T1, arg2: T2) => void,
     options?: { once?: boolean },
-  ): KnockoutSubscription;
+  ): ko.Subscription;
   /** Subscribe callback to some `@event` property */
   subscribe<T1, T2, T3>(
     event: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => void,
     callback: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => void,
     options?: { once?: boolean },
-  ): KnockoutSubscription;
+  ): ko.Subscription;
 
   /** Get internal ko.observable() for class property decodated by `@observable` */
   unwrap(key: string | symbol): any;
   /** Get internal ko.observable() for class property decodated by `@observable` */
-  unwrap<T>(key: string | symbol): KnockoutObservable<T>;
+  unwrap<T>(key: string | symbol): ko.Observable<T>;
 }
 
 /**
@@ -532,7 +532,7 @@ export function Disposable<T extends new (...args: any[]) => any>(
   return class extends Base {
     /** Dispose all subscriptions from this class */
     dispose() {
-      const subscriptions: KnockoutSubscription[] = this[SUBSCRIPTIONS_KEY as any];
+      const subscriptions: ko.Subscription[] = this[SUBSCRIPTIONS_KEY as any];
       if (subscriptions) {
         subscriptions.forEach((subscription) => {
           subscription.dispose();
@@ -543,8 +543,8 @@ export function Disposable<T extends new (...args: any[]) => any>(
 
     /** Subscribe callback to `@observable` or `@computed` dependency changes or to some `@event` */
     subscribe() {
-      const subscription: KnockoutSubscription = subscribe.apply(null, arguments);
-      const subscriptions: KnockoutSubscription[] = this[SUBSCRIPTIONS_KEY as any] ||
+      const subscription: ko.Subscription = subscribe.apply(null, arguments);
+      const subscriptions: ko.Subscription[] = this[SUBSCRIPTIONS_KEY as any] ||
         (this[SUBSCRIPTIONS_KEY as any] = []);
       subscriptions.push(subscription);
       return subscription;

--- a/src/observable-array.ts
+++ b/src/observable-array.ts
@@ -7,7 +7,7 @@ import { ArrayPrototype, arraySlice, defineProperty, hasOwnProperty, isArray, PA
 import { prepareDeepValue } from "./observable-property";
 import { applyExtenders } from "./property-extenders";
 
-type ObsArray = KnockoutObservableArray<any> & { [fnName: string]: Function };
+type ObsArray = ko.ObservableArray<any> & { [fnName: string]: Function };
 
 const deepArrayMethods = ["pop", "reverse", "shift", "sort"];
 const allArrayMethods = [...deepArrayMethods, "push", "splice", "unshift"];

--- a/src/property-extenders.ts
+++ b/src/property-extenders.ts
@@ -12,7 +12,7 @@ interface ExtendersDictionary {
 
 export function applyExtenders(
   instance: Object, key: string | symbol,
-  target: KnockoutObservable<any> | KnockoutComputed<any>,
+  target: ko.Observable<any> | ko.Computed<any>,
 ) {
   const dictionary = instance[EXTENDERS_KEY] as ExtendersDictionary;
   const extenders = dictionary && dictionary[key as any];

--- a/test/component-decorator-test.ts
+++ b/test/component-decorator-test.ts
@@ -5,7 +5,7 @@
 import * as ko from "knockout";
 import { component } from "../src/knockout-decorators";
 
-interface ComponentConfig extends KnockoutComponentTypes.ComponentConfig {
+interface ComponentConfig extends ko.components.Config {
   synchronous?: boolean;
 }
 

--- a/test/deep-observable-decorator-test.ts
+++ b/test/deep-observable-decorator-test.ts
@@ -369,8 +369,8 @@ describe("@observable({ deep: true }) decorator: initialized by array", () => {
     }
 
     const vm = new ViewModel();
-    const changesFirst: KnockoutArrayChange<number>[] = [];
-    const changesSecond: KnockoutArrayChange<number>[] = [];
+    const changesFirst: ko.utils.ArrayChange<number>[] = [];
+    const changesSecond: ko.utils.ArrayChange<number>[] = [];
 
     vm.first.subscribe((val) => { changesFirst.push(...val); }, null, "arrayChange");
     vm.second.subscribe((val) => { changesSecond.push(...val); }, null, "arrayChange");
@@ -457,8 +457,8 @@ describe("@observable({ deep: true }) decorator: initialized by array", () => {
     }
 
     const vm = new ViewModel();
-    const changesFirst: KnockoutArrayChange<number>[] = [];
-    const changesSecond: KnockoutArrayChange<number>[] = [];
+    const changesFirst: ko.utils.ArrayChange<number>[] = [];
+    const changesSecond: ko.utils.ArrayChange<number>[] = [];
 
     vm.arrayFirst.subscribe((val) => { changesFirst.push(...val); }, null, "arrayChange");
     vm.arraySecond.subscribe((val) => { changesSecond.push(...val); }, null, "arrayChange");
@@ -490,7 +490,7 @@ describe("@observable({ deep: true }) decorator: initialized by array", () => {
     }
 
     const vm = new ViewModel();
-    const changes: KnockoutArrayChange<number>[] = [];
+    const changes: ko.utils.ArrayChange<number>[] = [];
 
     vm.array.subscribe((val) => { changes.push(...val); }, null, "arrayChange");
 
@@ -512,7 +512,7 @@ describe("@observable({ deep: true }) decorator: initialized by array", () => {
     }
 
     const vm = new ViewModel();
-    const changes: KnockoutArrayChange<number>[] = [];
+    const changes: ko.utils.ArrayChange<number>[] = [];
 
     vm.array.subscribe((val) => { changes.push(...val); }, null, "arrayChange");
 

--- a/test/experimental/observable-array-proxy-test.ts
+++ b/test/experimental/observable-array-proxy-test.ts
@@ -8,7 +8,7 @@ import { subscribe, unwrap } from "../../src/knockout-decorators";
 import { prepareDeepValue } from "../../src/observable-property";
 
 describe("deep ObservableArray", () => {
-  function makeProxy<T>(array: T[]): T[] & KnockoutObservableArray<T> {
+  function makeProxy<T>(array: T[]): T[] & ko.ObservableArray<T> {
     return new ObservableArrayProxy(
       ko.observableArray(array), prepareDeepValue as any,
     ) as any;

--- a/test/extend-decorator-test.ts
+++ b/test/extend-decorator-test.ts
@@ -7,7 +7,7 @@ import * as ko from "knockout";
 import { computed, extend, observable, observableArray, subscribe } from "../src/knockout-decorators";
 
 describe("@extend decorator", () => {
-  ko.extenders["reverse"] = (target: KnockoutObservable<any>, options: "read" | "write") => {
+  ko.extenders["reverse"] = (target: ko.Observable<any>, options: "read" | "write") => {
     if (options === "read") {
       return ko.pureComputed({
         read: () => reverse(target()),
@@ -28,7 +28,7 @@ describe("@extend decorator", () => {
     }
   };
 
-  ko.extenders["upperCase"] = (target: KnockoutObservable<any>, options: "read" | "write") => {
+  ko.extenders["upperCase"] = (target: ko.Observable<any>, options: "read" | "write") => {
     if (options === "read") {
       return ko.pureComputed({
         read: () => String(target()).toUpperCase(),

--- a/test/legacy/knockout-decorators-test.ts
+++ b/test/legacy/knockout-decorators-test.ts
@@ -35,7 +35,7 @@ describe("legacy environments", () => {
   });
 
   describe("@autobind decorator", () => {
-    ko.extenders["reverse"] = (target: KnockoutObservable<any>) => {
+    ko.extenders["reverse"] = (target: ko.Observable<any>) => {
       return ko.pureComputed({
         read: target,
         write: (value: any) => target(value.split("").reverse().join("")),

--- a/test/observable-array-decorator-test.ts
+++ b/test/observable-array-decorator-test.ts
@@ -71,7 +71,7 @@ describe("@observableArray decorator", () => {
     }
 
     const vm = new ViewModel();
-    const changes: KnockoutArrayChange<number>[] = [];
+    const changes: ko.utils.ArrayChange<number>[] = [];
 
     vm.array.subscribe((val) => { changes.push(...val); }, null, "arrayChange");
 
@@ -117,8 +117,8 @@ describe("@observableArray decorator", () => {
     }
 
     const vm = new ViewModel();
-    const changesFirst: KnockoutArrayChange<number>[] = [];
-    const changesSecond: KnockoutArrayChange<number>[] = [];
+    const changesFirst: ko.utils.ArrayChange<number>[] = [];
+    const changesSecond: ko.utils.ArrayChange<number>[] = [];
 
     vm.arrayFirst.subscribe((val) => { changesFirst.push(...val); }, null, "arrayChange");
     vm.arraySecond.subscribe((val) => { changesSecond.push(...val); }, null, "arrayChange");
@@ -149,7 +149,7 @@ describe("@observableArray decorator", () => {
     }
 
     const vm = new ViewModel();
-    const changes: KnockoutArrayChange<number>[] = [];
+    const changes: ko.utils.ArrayChange<number>[] = [];
 
     vm.array.subscribe((val) => { changes.push(...val); }, null, "arrayChange");
 
@@ -170,7 +170,7 @@ describe("@observableArray decorator", () => {
     }
 
     const vm = new ViewModel();
-    const changes: KnockoutArrayChange<number>[] = [];
+    const changes: ko.utils.ArrayChange<number>[] = [];
 
     vm.array.subscribe((val) => { changes.push(...val); }, null, "arrayChange");
 

--- a/test/subscribe-utility-test.ts
+++ b/test/subscribe-utility-test.ts
@@ -119,7 +119,7 @@ describe("subscribe utility function", () => {
     }
 
     const vm = new ViewModel();
-    const changes: KnockoutArrayChange<number>[] = [];
+    const changes: ko.utils.ArrayChange<number>[] = [];
 
     subscribe(() => vm.array, (val) => {
       changes.push(...val);
@@ -241,7 +241,7 @@ describe("subscribe utility function", () => {
     }
 
     const vm = new ViewModel();
-    const changes: KnockoutArrayChange<number>[] = [];
+    const changes: ko.utils.ArrayChange<number>[] = [];
 
     subscribe(() => vm.array, (val) => {
       changes.push(...val);

--- a/test/subscribe-utility-test.ts
+++ b/test/subscribe-utility-test.ts
@@ -5,7 +5,7 @@
 Symbol = undefined as any;
 import * as ko from "knockout";
 import {
-  computed, observable, observableArray, ObservableArray, subscribe, extend,
+  computed, extend, observable, observableArray, ObservableArray, subscribe,
 } from "../src/knockout-decorators";
 
 describe("subscribe utility function", () => {

--- a/test/unwrap-utility-test.ts
+++ b/test/unwrap-utility-test.ts
@@ -84,7 +84,7 @@ describe("unwrap utility function", () => {
     expect(instance.property).toBe("observable value");
   });
 
-  ko.extenders["required"] = (target: KnockoutObservable<any>) => {
+  ko.extenders["required"] = (target: ko.Observable<any>) => {
     const extendedObservable = ko.pureComputed({
       read: target,
       write: (value) => {


### PR DESCRIPTION
This PR tries to solve https://github.com/gnaeus/knockout-decorators/issues/17.
Switching to knockout 3.5.0 in our projects lead to typescript compile errors, because the kncokout embedded types do not match the ones in @types/knockout.
Unfortunately knockout-decorators is still using types from @types/knockout, so the type mismatch cannot be resolved until there is a knockout-decorators version with the embedded knockout types.